### PR TITLE
More fiducial options in Production Frame generator

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "dependencies/Triangle.NET"]
+	path = dependencies/Triangle.NET
+	url = https://github.com/eppz/Triangle.NET.git

--- a/GerberLibrary/GerberLibrary.csproj
+++ b/GerberLibrary/GerberLibrary.csproj
@@ -67,9 +67,6 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="Triangle, Version=0.0.6.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Triangle.0.0.6-Beta3\lib\net45\Triangle.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Artwork Related\BasicBounce.cs" />
@@ -114,7 +111,12 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <ProjectReference Include="..\dependencies\Triangle.NET\Triangle.NET\Triangle\Triangle.csproj">
+      <Project>{f7907a0a-b75f-400b-9e78-bfad00db4d6b}</Project>
+      <Name>Triangle</Name>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/GerberProjects/GerberProjects.sln
+++ b/GerberProjects/GerberProjects.sln
@@ -78,6 +78,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FrontPanelBuilder", "..\Fro
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GerberToDxf", "..\GerberToDxf\GerberToDxf\GerberToDxf.csproj", "{843057E6-2FC0-4C78-AAB3-197C60AE72BF}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "dependencies", "dependencies", "{AAAFD0A7-47D1-4530-86CA-B68C5790E7C1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Triangle", "..\dependencies\Triangle.NET\Triangle.NET\Triangle\Triangle.csproj", "{F7907A0A-B75F-400B-9E78-BFAD00DB4D6B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -326,6 +330,14 @@ Global
 		{843057E6-2FC0-4C78-AAB3-197C60AE72BF}.Release|Any CPU.Build.0 = Release|Any CPU
 		{843057E6-2FC0-4C78-AAB3-197C60AE72BF}.Release|x86.ActiveCfg = Release|Any CPU
 		{843057E6-2FC0-4C78-AAB3-197C60AE72BF}.Release|x86.Build.0 = Release|Any CPU
+		{F7907A0A-B75F-400B-9E78-BFAD00DB4D6B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F7907A0A-B75F-400B-9E78-BFAD00DB4D6B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F7907A0A-B75F-400B-9E78-BFAD00DB4D6B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F7907A0A-B75F-400B-9E78-BFAD00DB4D6B}.Debug|x86.Build.0 = Debug|Any CPU
+		{F7907A0A-B75F-400B-9E78-BFAD00DB4D6B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F7907A0A-B75F-400B-9E78-BFAD00DB4D6B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F7907A0A-B75F-400B-9E78-BFAD00DB4D6B}.Release|x86.ActiveCfg = Release|Any CPU
+		{F7907A0A-B75F-400B-9E78-BFAD00DB4D6B}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -361,6 +373,10 @@ Global
 		{822016C1-52B8-449C-BE7A-D3ABA943B8B6} = {5B17443F-D48D-429E-83E3-2C7DCA8C6ED3}
 		{485C42A7-B359-4091-9BE7-7B8E99A8D7EA} = {5B17443F-D48D-429E-83E3-2C7DCA8C6ED3}
 		{843057E6-2FC0-4C78-AAB3-197C60AE72BF} = {F705564A-6956-4675-A941-6ED916ADC0AD}
+		{F7907A0A-B75F-400B-9E78-BFAD00DB4D6B} = {AAAFD0A7-47D1-4530-86CA-B68C5790E7C1}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {D3E1B175-5E33-4A46-8DBC-A8B9B4A50987}
 	EndGlobalSection
 	GlobalSection(Performance) = preSolution
 		HasPerformanceSessions = true

--- a/ProductionFrame/ProductionFrameForm.Designer.cs
+++ b/ProductionFrame/ProductionFrameForm.Designer.cs
@@ -33,7 +33,7 @@
             this.flowLayoutPanel9 = new System.Windows.Forms.FlowLayoutPanel();
             this.label8 = new System.Windows.Forms.Label();
             this.FrameTitleBox = new System.Windows.Forms.TextBox();
-            this.fiducials = new System.Windows.Forms.CheckBox();
+            this.cb_fiductialsTopLayer = new System.Windows.Forms.CheckBox();
             this.addHolesCheck = new System.Windows.Forms.CheckBox();
             this.flowLayoutPanel4 = new System.Windows.Forms.FlowLayoutPanel();
             this.label3 = new System.Windows.Forms.Label();
@@ -65,6 +65,8 @@
             this.label15 = new System.Windows.Forms.Label();
             this.button1 = new System.Windows.Forms.Button();
             this.saveFileDialog1 = new System.Windows.Forms.SaveFileDialog();
+            this.cb_fiductialsBottomLayer = new System.Windows.Forms.CheckBox();
+            this.cb_fiducials_orientationSafe = new System.Windows.Forms.CheckBox();
             this.flowLayoutPanel1.SuspendLayout();
             this.flowLayoutPanel9.SuspendLayout();
             this.flowLayoutPanel4.SuspendLayout();
@@ -87,7 +89,9 @@
             // 
             this.flowLayoutPanel1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.flowLayoutPanel1.Controls.Add(this.flowLayoutPanel9);
-            this.flowLayoutPanel1.Controls.Add(this.fiducials);
+            this.flowLayoutPanel1.Controls.Add(this.cb_fiductialsTopLayer);
+            this.flowLayoutPanel1.Controls.Add(this.cb_fiductialsBottomLayer);
+            this.flowLayoutPanel1.Controls.Add(this.cb_fiducials_orientationSafe);
             this.flowLayoutPanel1.Controls.Add(this.addHolesCheck);
             this.flowLayoutPanel1.Controls.Add(this.flowLayoutPanel4);
             this.flowLayoutPanel1.Controls.Add(this.flowLayoutPanel2);
@@ -100,8 +104,9 @@
             this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.flowLayoutPanel1.FlowDirection = System.Windows.Forms.FlowDirection.TopDown;
             this.flowLayoutPanel1.Location = new System.Drawing.Point(0, 0);
+            this.flowLayoutPanel1.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.flowLayoutPanel1.Name = "flowLayoutPanel1";
-            this.flowLayoutPanel1.Size = new System.Drawing.Size(427, 452);
+            this.flowLayoutPanel1.Size = new System.Drawing.Size(320, 367);
             this.flowLayoutPanel1.TabIndex = 0;
             // 
             // flowLayoutPanel9
@@ -109,48 +114,53 @@
             this.flowLayoutPanel9.AutoSize = true;
             this.flowLayoutPanel9.Controls.Add(this.label8);
             this.flowLayoutPanel9.Controls.Add(this.FrameTitleBox);
-            this.flowLayoutPanel9.Location = new System.Drawing.Point(3, 3);
+            this.flowLayoutPanel9.Location = new System.Drawing.Point(2, 2);
+            this.flowLayoutPanel9.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.flowLayoutPanel9.Name = "flowLayoutPanel9";
-            this.flowLayoutPanel9.Size = new System.Drawing.Size(341, 28);
+            this.flowLayoutPanel9.Size = new System.Drawing.Size(255, 24);
             this.flowLayoutPanel9.TabIndex = 11;
             // 
             // label8
             // 
             this.label8.AutoSize = true;
-            this.label8.Location = new System.Drawing.Point(3, 0);
+            this.label8.Location = new System.Drawing.Point(2, 0);
+            this.label8.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label8.Name = "label8";
-            this.label8.Size = new System.Drawing.Size(79, 17);
+            this.label8.Size = new System.Drawing.Size(59, 13);
             this.label8.TabIndex = 2;
             this.label8.Text = "Frame Title";
             // 
             // FrameTitleBox
             // 
-            this.FrameTitleBox.Location = new System.Drawing.Point(88, 3);
+            this.FrameTitleBox.Location = new System.Drawing.Point(65, 2);
+            this.FrameTitleBox.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.FrameTitleBox.Name = "FrameTitleBox";
-            this.FrameTitleBox.Size = new System.Drawing.Size(250, 22);
+            this.FrameTitleBox.Size = new System.Drawing.Size(188, 20);
             this.FrameTitleBox.TabIndex = 4;
             this.FrameTitleBox.Text = "FrameTitle";
             // 
-            // fiducials
+            // cb_fiductialsTopLayer
             // 
-            this.fiducials.AutoSize = true;
-            this.fiducials.Checked = true;
-            this.fiducials.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.fiducials.Location = new System.Drawing.Point(3, 37);
-            this.fiducials.Name = "fiducials";
-            this.fiducials.Size = new System.Drawing.Size(114, 21);
-            this.fiducials.TabIndex = 0;
-            this.fiducials.Text = "Add Fiducials";
-            this.fiducials.UseVisualStyleBackColor = true;
+            this.cb_fiductialsTopLayer.AutoSize = true;
+            this.cb_fiductialsTopLayer.Checked = true;
+            this.cb_fiductialsTopLayer.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.cb_fiductialsTopLayer.Location = new System.Drawing.Point(2, 30);
+            this.cb_fiductialsTopLayer.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.cb_fiductialsTopLayer.Name = "cb_fiductialsTopLayer";
+            this.cb_fiductialsTopLayer.Size = new System.Drawing.Size(89, 17);
+            this.cb_fiductialsTopLayer.TabIndex = 0;
+            this.cb_fiductialsTopLayer.Text = "Add Fiducials";
+            this.cb_fiductialsTopLayer.UseVisualStyleBackColor = true;
             // 
             // addHolesCheck
             // 
             this.addHolesCheck.AutoSize = true;
             this.addHolesCheck.Checked = true;
             this.addHolesCheck.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.addHolesCheck.Location = new System.Drawing.Point(3, 64);
+            this.addHolesCheck.Location = new System.Drawing.Point(2, 97);
+            this.addHolesCheck.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.addHolesCheck.Name = "addHolesCheck";
-            this.addHolesCheck.Size = new System.Drawing.Size(95, 21);
+            this.addHolesCheck.Size = new System.Drawing.Size(75, 17);
             this.addHolesCheck.TabIndex = 2;
             this.addHolesCheck.Text = "Add Holes";
             this.addHolesCheck.UseVisualStyleBackColor = true;
@@ -161,26 +171,29 @@
             this.flowLayoutPanel4.Controls.Add(this.label3);
             this.flowLayoutPanel4.Controls.Add(this.holeDiameter);
             this.flowLayoutPanel4.Controls.Add(this.label10);
-            this.flowLayoutPanel4.Location = new System.Drawing.Point(3, 91);
+            this.flowLayoutPanel4.Location = new System.Drawing.Point(2, 118);
+            this.flowLayoutPanel4.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.flowLayoutPanel4.Name = "flowLayoutPanel4";
-            this.flowLayoutPanel4.Size = new System.Drawing.Size(266, 28);
+            this.flowLayoutPanel4.Size = new System.Drawing.Size(199, 24);
             this.flowLayoutPanel4.TabIndex = 6;
             // 
             // label3
             // 
             this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(3, 0);
+            this.label3.Location = new System.Drawing.Point(2, 0);
+            this.label3.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(98, 17);
+            this.label3.Size = new System.Drawing.Size(74, 13);
             this.label3.TabIndex = 2;
             this.label3.Text = "Hole Diameter";
             // 
             // holeDiameter
             // 
             this.holeDiameter.DecimalPlaces = 1;
-            this.holeDiameter.Location = new System.Drawing.Point(107, 3);
+            this.holeDiameter.Location = new System.Drawing.Point(80, 2);
+            this.holeDiameter.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.holeDiameter.Name = "holeDiameter";
-            this.holeDiameter.Size = new System.Drawing.Size(120, 22);
+            this.holeDiameter.Size = new System.Drawing.Size(90, 20);
             this.holeDiameter.TabIndex = 1;
             this.holeDiameter.Value = new decimal(new int[] {
             32,
@@ -191,9 +204,10 @@
             // label10
             // 
             this.label10.AutoSize = true;
-            this.label10.Location = new System.Drawing.Point(233, 0);
+            this.label10.Location = new System.Drawing.Point(174, 0);
+            this.label10.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label10.Name = "label10";
-            this.label10.Size = new System.Drawing.Size(30, 17);
+            this.label10.Size = new System.Drawing.Size(23, 13);
             this.label10.TabIndex = 4;
             this.label10.Text = "mm";
             // 
@@ -203,26 +217,29 @@
             this.flowLayoutPanel2.Controls.Add(this.label1);
             this.flowLayoutPanel2.Controls.Add(this.topEdge);
             this.flowLayoutPanel2.Controls.Add(this.label9);
-            this.flowLayoutPanel2.Location = new System.Drawing.Point(3, 125);
+            this.flowLayoutPanel2.Location = new System.Drawing.Point(2, 146);
+            this.flowLayoutPanel2.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.flowLayoutPanel2.Name = "flowLayoutPanel2";
-            this.flowLayoutPanel2.Size = new System.Drawing.Size(285, 28);
+            this.flowLayoutPanel2.Size = new System.Drawing.Size(216, 24);
             this.flowLayoutPanel2.TabIndex = 4;
             // 
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(3, 0);
+            this.label1.Location = new System.Drawing.Point(2, 0);
+            this.label1.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(117, 17);
+            this.label1.Size = new System.Drawing.Size(91, 13);
             this.label1.TabIndex = 2;
             this.label1.Text = "Top/Bottom edge";
             // 
             // topEdge
             // 
             this.topEdge.DecimalPlaces = 1;
-            this.topEdge.Location = new System.Drawing.Point(126, 3);
+            this.topEdge.Location = new System.Drawing.Point(97, 2);
+            this.topEdge.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.topEdge.Name = "topEdge";
-            this.topEdge.Size = new System.Drawing.Size(120, 22);
+            this.topEdge.Size = new System.Drawing.Size(90, 20);
             this.topEdge.TabIndex = 1;
             this.topEdge.Value = new decimal(new int[] {
             10,
@@ -233,9 +250,10 @@
             // label9
             // 
             this.label9.AutoSize = true;
-            this.label9.Location = new System.Drawing.Point(252, 0);
+            this.label9.Location = new System.Drawing.Point(191, 0);
+            this.label9.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label9.Name = "label9";
-            this.label9.Size = new System.Drawing.Size(30, 17);
+            this.label9.Size = new System.Drawing.Size(23, 13);
             this.label9.TabIndex = 3;
             this.label9.Text = "mm";
             // 
@@ -245,26 +263,29 @@
             this.flowLayoutPanel3.Controls.Add(this.label2);
             this.flowLayoutPanel3.Controls.Add(this.leftEdge);
             this.flowLayoutPanel3.Controls.Add(this.label11);
-            this.flowLayoutPanel3.Location = new System.Drawing.Point(3, 159);
+            this.flowLayoutPanel3.Location = new System.Drawing.Point(2, 174);
+            this.flowLayoutPanel3.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.flowLayoutPanel3.Name = "flowLayoutPanel3";
-            this.flowLayoutPanel3.Size = new System.Drawing.Size(273, 28);
+            this.flowLayoutPanel3.Size = new System.Drawing.Size(207, 24);
             this.flowLayoutPanel3.TabIndex = 5;
             // 
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(3, 0);
+            this.label2.Location = new System.Drawing.Point(2, 0);
+            this.label2.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(105, 17);
+            this.label2.Size = new System.Drawing.Size(82, 13);
             this.label2.TabIndex = 2;
             this.label2.Text = "Left/Right edge";
             // 
             // leftEdge
             // 
             this.leftEdge.DecimalPlaces = 1;
-            this.leftEdge.Location = new System.Drawing.Point(114, 3);
+            this.leftEdge.Location = new System.Drawing.Point(88, 2);
+            this.leftEdge.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.leftEdge.Name = "leftEdge";
-            this.leftEdge.Size = new System.Drawing.Size(120, 22);
+            this.leftEdge.Size = new System.Drawing.Size(90, 20);
             this.leftEdge.TabIndex = 1;
             this.leftEdge.Value = new decimal(new int[] {
             10,
@@ -275,9 +296,10 @@
             // label11
             // 
             this.label11.AutoSize = true;
-            this.label11.Location = new System.Drawing.Point(240, 0);
+            this.label11.Location = new System.Drawing.Point(182, 0);
+            this.label11.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label11.Name = "label11";
-            this.label11.Size = new System.Drawing.Size(30, 17);
+            this.label11.Size = new System.Drawing.Size(23, 13);
             this.label11.TabIndex = 4;
             this.label11.Text = "mm";
             // 
@@ -287,26 +309,29 @@
             this.flowLayoutPanel5.Controls.Add(this.label4);
             this.flowLayoutPanel5.Controls.Add(this.roundedOuterCorners);
             this.flowLayoutPanel5.Controls.Add(this.label12);
-            this.flowLayoutPanel5.Location = new System.Drawing.Point(3, 193);
+            this.flowLayoutPanel5.Location = new System.Drawing.Point(2, 202);
+            this.flowLayoutPanel5.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.flowLayoutPanel5.Name = "flowLayoutPanel5";
-            this.flowLayoutPanel5.Size = new System.Drawing.Size(328, 28);
+            this.flowLayoutPanel5.Size = new System.Drawing.Size(244, 24);
             this.flowLayoutPanel5.TabIndex = 7;
             // 
             // label4
             // 
             this.label4.AutoSize = true;
-            this.label4.Location = new System.Drawing.Point(3, 0);
+            this.label4.Location = new System.Drawing.Point(2, 0);
+            this.label4.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(160, 17);
+            this.label4.Size = new System.Drawing.Size(119, 13);
             this.label4.TabIndex = 2;
             this.label4.Text = "Rounded Outer Corners";
             // 
             // roundedOuterCorners
             // 
             this.roundedOuterCorners.DecimalPlaces = 1;
-            this.roundedOuterCorners.Location = new System.Drawing.Point(169, 3);
+            this.roundedOuterCorners.Location = new System.Drawing.Point(125, 2);
+            this.roundedOuterCorners.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.roundedOuterCorners.Name = "roundedOuterCorners";
-            this.roundedOuterCorners.Size = new System.Drawing.Size(120, 22);
+            this.roundedOuterCorners.Size = new System.Drawing.Size(90, 20);
             this.roundedOuterCorners.TabIndex = 1;
             this.roundedOuterCorners.Value = new decimal(new int[] {
             5,
@@ -317,9 +342,10 @@
             // label12
             // 
             this.label12.AutoSize = true;
-            this.label12.Location = new System.Drawing.Point(295, 0);
+            this.label12.Location = new System.Drawing.Point(219, 0);
+            this.label12.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label12.Name = "label12";
-            this.label12.Size = new System.Drawing.Size(30, 17);
+            this.label12.Size = new System.Drawing.Size(23, 13);
             this.label12.TabIndex = 4;
             this.label12.Text = "mm";
             // 
@@ -329,26 +355,29 @@
             this.flowLayoutPanel8.Controls.Add(this.label7);
             this.flowLayoutPanel8.Controls.Add(this.roundedInnerCorners);
             this.flowLayoutPanel8.Controls.Add(this.label13);
-            this.flowLayoutPanel8.Location = new System.Drawing.Point(3, 227);
+            this.flowLayoutPanel8.Location = new System.Drawing.Point(2, 230);
+            this.flowLayoutPanel8.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.flowLayoutPanel8.Name = "flowLayoutPanel8";
-            this.flowLayoutPanel8.Size = new System.Drawing.Size(324, 28);
+            this.flowLayoutPanel8.Size = new System.Drawing.Size(242, 24);
             this.flowLayoutPanel8.TabIndex = 10;
             // 
             // label7
             // 
             this.label7.AutoSize = true;
-            this.label7.Location = new System.Drawing.Point(3, 0);
+            this.label7.Location = new System.Drawing.Point(2, 0);
+            this.label7.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label7.Name = "label7";
-            this.label7.Size = new System.Drawing.Size(156, 17);
+            this.label7.Size = new System.Drawing.Size(117, 13);
             this.label7.TabIndex = 2;
             this.label7.Text = "Rounded Inner Corners";
             // 
             // roundedInnerCorners
             // 
             this.roundedInnerCorners.DecimalPlaces = 1;
-            this.roundedInnerCorners.Location = new System.Drawing.Point(165, 3);
+            this.roundedInnerCorners.Location = new System.Drawing.Point(123, 2);
+            this.roundedInnerCorners.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.roundedInnerCorners.Name = "roundedInnerCorners";
-            this.roundedInnerCorners.Size = new System.Drawing.Size(120, 22);
+            this.roundedInnerCorners.Size = new System.Drawing.Size(90, 20);
             this.roundedInnerCorners.TabIndex = 1;
             this.roundedInnerCorners.Value = new decimal(new int[] {
             1,
@@ -359,9 +388,10 @@
             // label13
             // 
             this.label13.AutoSize = true;
-            this.label13.Location = new System.Drawing.Point(291, 0);
+            this.label13.Location = new System.Drawing.Point(217, 0);
+            this.label13.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label13.Name = "label13";
-            this.label13.Size = new System.Drawing.Size(30, 17);
+            this.label13.Size = new System.Drawing.Size(23, 13);
             this.label13.TabIndex = 4;
             this.label13.Text = "mm";
             // 
@@ -371,26 +401,29 @@
             this.flowLayoutPanel6.Controls.Add(this.label5);
             this.flowLayoutPanel6.Controls.Add(this.innerWidth);
             this.flowLayoutPanel6.Controls.Add(this.label14);
-            this.flowLayoutPanel6.Location = new System.Drawing.Point(3, 261);
+            this.flowLayoutPanel6.Location = new System.Drawing.Point(2, 258);
+            this.flowLayoutPanel6.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.flowLayoutPanel6.Name = "flowLayoutPanel6";
-            this.flowLayoutPanel6.Size = new System.Drawing.Size(248, 28);
+            this.flowLayoutPanel6.Size = new System.Drawing.Size(187, 24);
             this.flowLayoutPanel6.TabIndex = 8;
             // 
             // label5
             // 
             this.label5.AutoSize = true;
-            this.label5.Location = new System.Drawing.Point(3, 0);
+            this.label5.Location = new System.Drawing.Point(2, 0);
+            this.label5.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label5.Name = "label5";
-            this.label5.Size = new System.Drawing.Size(80, 17);
+            this.label5.Size = new System.Drawing.Size(62, 13);
             this.label5.TabIndex = 2;
             this.label5.Text = "Inner Width";
             // 
             // innerWidth
             // 
             this.innerWidth.DecimalPlaces = 1;
-            this.innerWidth.Location = new System.Drawing.Point(89, 3);
+            this.innerWidth.Location = new System.Drawing.Point(68, 2);
+            this.innerWidth.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.innerWidth.Name = "innerWidth";
-            this.innerWidth.Size = new System.Drawing.Size(120, 22);
+            this.innerWidth.Size = new System.Drawing.Size(90, 20);
             this.innerWidth.TabIndex = 1;
             this.innerWidth.Value = new decimal(new int[] {
             100,
@@ -401,9 +434,10 @@
             // label14
             // 
             this.label14.AutoSize = true;
-            this.label14.Location = new System.Drawing.Point(215, 0);
+            this.label14.Location = new System.Drawing.Point(162, 0);
+            this.label14.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label14.Name = "label14";
-            this.label14.Size = new System.Drawing.Size(30, 17);
+            this.label14.Size = new System.Drawing.Size(23, 13);
             this.label14.TabIndex = 4;
             this.label14.Text = "mm";
             // 
@@ -413,26 +447,29 @@
             this.flowLayoutPanel7.Controls.Add(this.label6);
             this.flowLayoutPanel7.Controls.Add(this.innerHeight);
             this.flowLayoutPanel7.Controls.Add(this.label15);
-            this.flowLayoutPanel7.Location = new System.Drawing.Point(3, 295);
+            this.flowLayoutPanel7.Location = new System.Drawing.Point(2, 286);
+            this.flowLayoutPanel7.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.flowLayoutPanel7.Name = "flowLayoutPanel7";
-            this.flowLayoutPanel7.Size = new System.Drawing.Size(253, 28);
+            this.flowLayoutPanel7.Size = new System.Drawing.Size(190, 24);
             this.flowLayoutPanel7.TabIndex = 9;
             // 
             // label6
             // 
             this.label6.AutoSize = true;
-            this.label6.Location = new System.Drawing.Point(3, 0);
+            this.label6.Location = new System.Drawing.Point(2, 0);
+            this.label6.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label6.Name = "label6";
-            this.label6.Size = new System.Drawing.Size(85, 17);
+            this.label6.Size = new System.Drawing.Size(65, 13);
             this.label6.TabIndex = 2;
             this.label6.Text = "Inner Height";
             // 
             // innerHeight
             // 
             this.innerHeight.DecimalPlaces = 1;
-            this.innerHeight.Location = new System.Drawing.Point(94, 3);
+            this.innerHeight.Location = new System.Drawing.Point(71, 2);
+            this.innerHeight.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.innerHeight.Name = "innerHeight";
-            this.innerHeight.Size = new System.Drawing.Size(120, 22);
+            this.innerHeight.Size = new System.Drawing.Size(90, 20);
             this.innerHeight.TabIndex = 1;
             this.innerHeight.Value = new decimal(new int[] {
             100,
@@ -443,29 +480,56 @@
             // label15
             // 
             this.label15.AutoSize = true;
-            this.label15.Location = new System.Drawing.Point(220, 0);
+            this.label15.Location = new System.Drawing.Point(165, 0);
+            this.label15.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label15.Name = "label15";
-            this.label15.Size = new System.Drawing.Size(30, 17);
+            this.label15.Size = new System.Drawing.Size(23, 13);
             this.label15.TabIndex = 4;
             this.label15.Text = "mm";
             // 
             // button1
             // 
-            this.button1.Location = new System.Drawing.Point(3, 329);
+            this.button1.Location = new System.Drawing.Point(2, 314);
+            this.button1.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.button1.Name = "button1";
-            this.button1.Size = new System.Drawing.Size(149, 36);
+            this.button1.Size = new System.Drawing.Size(112, 29);
             this.button1.TabIndex = 3;
             this.button1.Text = "Generate!";
             this.button1.UseVisualStyleBackColor = true;
             this.button1.Click += new System.EventHandler(this.button1_Click);
             // 
+            // cb_fiductialsBottomLayer
+            // 
+            this.cb_fiductialsBottomLayer.AutoSize = true;
+            this.cb_fiductialsBottomLayer.Checked = true;
+            this.cb_fiductialsBottomLayer.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.cb_fiductialsBottomLayer.Location = new System.Drawing.Point(3, 52);
+            this.cb_fiductialsBottomLayer.Name = "cb_fiductialsBottomLayer";
+            this.cb_fiductialsBottomLayer.Size = new System.Drawing.Size(161, 17);
+            this.cb_fiductialsBottomLayer.TabIndex = 12;
+            this.cb_fiductialsBottomLayer.Text = "Add fiducials on bottom layer";
+            this.cb_fiductialsBottomLayer.UseVisualStyleBackColor = true;
+            // 
+            // cb_fiducials_orientationSafe
+            // 
+            this.cb_fiducials_orientationSafe.AutoSize = true;
+            this.cb_fiducials_orientationSafe.Checked = true;
+            this.cb_fiducials_orientationSafe.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.cb_fiducials_orientationSafe.Location = new System.Drawing.Point(3, 75);
+            this.cb_fiducials_orientationSafe.Name = "cb_fiducials_orientationSafe";
+            this.cb_fiducials_orientationSafe.Size = new System.Drawing.Size(239, 17);
+            this.cb_fiducials_orientationSafe.TabIndex = 13;
+            this.cb_fiducials_orientationSafe.Text = "Orientation safe fiducials (3 per selected side)";
+            this.cb_fiducials_orientationSafe.UseVisualStyleBackColor = true;
+            // 
             // ProductionFrameForm
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(427, 452);
+            this.ClientSize = new System.Drawing.Size(320, 367);
             this.Controls.Add(this.flowLayoutPanel1);
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
+            this.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.Name = "ProductionFrameForm";
             this.Text = "Production Frame Wizard";
             this.flowLayoutPanel1.ResumeLayout(false);
@@ -500,7 +564,7 @@
         #endregion
 
         private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel1;
-        private System.Windows.Forms.CheckBox fiducials;
+        private System.Windows.Forms.CheckBox cb_fiductialsTopLayer;
         private System.Windows.Forms.CheckBox addHolesCheck;
         private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel2;
         private System.Windows.Forms.Label label1;
@@ -535,6 +599,8 @@
         private System.Windows.Forms.Label label13;
         private System.Windows.Forms.Label label14;
         private System.Windows.Forms.Label label15;
+        private System.Windows.Forms.CheckBox cb_fiductialsBottomLayer;
+        private System.Windows.Forms.CheckBox cb_fiducials_orientationSafe;
     }
 }
 

--- a/ProductionFrame/ProductionFrameForm.cs
+++ b/ProductionFrame/ProductionFrameForm.cs
@@ -93,7 +93,7 @@ namespace ProductionFrame
                     Files.Add(OutName + ".txt");
                 }
 
-
+                // board outline
                 PolyLine PL = new PolyLine();
                 PL.MakeRoundedRect(new PointD(0, 0), new PointD(OuterWidth, OuterHeight), (double)roundedOuterCorners.Value);
                 Outline.AddPolyLine(PL, 0);
@@ -102,19 +102,36 @@ namespace ProductionFrame
                 PL2.MakeRoundedRect(new PointD(LE, TE), new PointD(InnerWidth + LE, InnerHeight + TE), (double)roundedInnerCorners.Value);
                 Outline.AddPolyLine(PL2, 0);
 
-                if (fiducials.Checked)
+                #region fiducials
+
+                List<PointD> Fiducials = new List<PointD>();
+                Fiducials.Add(new PointD(LE * 2.0, TE / 2.0));                              // bottom left
+                Fiducials.Add(new PointD(OuterWidth - LE * 2.0, TE / 2.0));                 // bottom right
+                Fiducials.Add(new PointD(LE * 2.0, OuterHeight - TE / 2.0));                // top left
+
+                // add the fourth fiducial only if no orientation safety is desired
+                if (!cb_fiducials_orientationSafe.Checked)
                 {
-                    List<PointD> Fiducials = new List<PointD>();
-                    Fiducials.Add(new PointD(LE * 2.0, TE / 2.0));
-                    Fiducials.Add(new PointD(OuterWidth - LE * 2.0, TE / 2.0));
-                    Fiducials.Add(new PointD(OuterWidth - LE * 2.0, OuterHeight - TE / 2.0));
-                    Fiducials.Add(new PointD(LE * 2.0, OuterHeight - TE / 2.0));
-                    foreach (var A in Fiducials)
+                    Fiducials.Add(new PointD(OuterWidth - LE * 2.0, OuterHeight - TE / 2.0));   // top right                    
+                }
+                                 
+                foreach (var A in Fiducials)
+                {
+                    if (cb_fiductialsTopLayer.Checked)
                     {
                         TopCopper.AddFlash(A, 1.0);
                         TopSolderMask.AddFlash(A, 3.0);
                     }
+
+                    if (cb_fiductialsBottomLayer.Checked)
+                    {
+                        BottomCopper.AddFlash(A, 1.0);
+                        BottomSolderMask.AddFlash(A, 3.0);
+                    }
                 }
+
+                #endregion
+
                 string FrameTitle = FrameTitleBox.Text;
 
                 if (FrameTitle.Length > 0)


### PR DESCRIPTION
Hi,

we wanted to have a few more options to the production frame generator so we added them.

What's new:
- fiducials on bottom layer as an option
- orientation safe fiducials (only 3 fids so that a P&P machine can recognize if the PCB is upside down or rotated - see renderings below)

Here's how a panel looks now (for our usage):

![testframe_combined_bottom](https://user-images.githubusercontent.com/90577/44386490-f2749d80-a522-11e8-9e60-372379d914f4.png) ![testframe_combined_top](https://user-images.githubusercontent.com/90577/44386491-f2749d80-a522-11e8-9cc2-05d6a30ac445.png)


Note: added Triangles.NET as git subrepo while getting your repo to build (commit f38d66a)