### PR TITLE
Add .gm1 as an alias of .gko

### DIFF
--- a/GerberLibrary/Core/Gerber.cs
+++ b/GerberLibrary/Core/Gerber.cs
@@ -373,6 +373,7 @@ namespace GerberLibrary
                 case "fabrd":
                 case "oln":
                 case "gko":
+                case "gm1":
                     Side = BoardSide.Both;
                     Layer = BoardLayer.Outline;
                     break;


### PR DESCRIPTION
Kicad exports board outlines as .gm1. 

As discussed in https://github.com/ThisIsNotRocketScience/GerberTools/pull/26 alias .gm1 to .gko

Signed-off-by: Alastair D'Silva <alastair@d-silva.org>