### PR TITLE
Fix Kicad slots

### DIFF
--- a/GerberLibrary/Core/GerberPanel.cs
+++ b/GerberLibrary/Core/GerberPanel.cs
@@ -1583,6 +1583,7 @@ namespace GerberLibrary
             {
                 string ext = Path.GetExtension(s).ToLower(); ;
                 if (ext == "xln") ext = "txt";
+                if (ext == "drl") ext = "txt";
                 if (FilesPerExt.ContainsKey(ext) == false)
                 {
                     FilesPerExt[ext] = new List<string>();

--- a/GerberLibrary/Core/GerberSplitter.cs
+++ b/GerberLibrary/Core/GerberSplitter.cs
@@ -260,7 +260,7 @@ namespace GerberLibrary
                 for (int i = 0; i < p.Length; i++)
                 {
                     char current = p[i];
-                    if (char.IsNumber(current) || current == '+' || current == '-')
+                    if (char.IsNumber(current) || current == '+' || current == '-' || (hasdecimalpoint && current == '.'))
                     {
                         isnumber = true;
                     }


### PR DESCRIPTION
Oval pads from Kicad gerbers were not emitted in the merged drill files.
As described in https://github.com/ThisIsNotRocketScience/GerberTools/issues/36
accept decimal values as valid.