### PR TITLE
Empty area fill tab fix v2

### DIFF
--- a/GerberLibrary/Core/GerberPanel.cs
+++ b/GerberLibrary/Core/GerberPanel.cs
@@ -218,7 +218,7 @@ namespace GerberLibrary
 
             foreach (var a in TheSet.Instances)
             {
-                if (a.GerberPath.Contains("???") == false)
+                if (a.GerberPath.Contains("???_negative") == false)
                 {
                     var outline = GerberOutlines[a.GerberPath];
                     var P = outline.GetActualCenter();
@@ -1144,7 +1144,7 @@ namespace GerberLibrary
             RemoveAllTabs();
             foreach (var a in TheSet.Instances)
             {
-                if (GerberOutlines.ContainsKey(a.GerberPath) && a.GerberPath.Contains("???") == false)
+                if (GerberOutlines.ContainsKey(a.GerberPath) && a.GerberPath.Contains("???_negative") == false)
                 {
                     var g = GerberOutlines[a.GerberPath];
                     var TabsLocs = PolyLineSet.FindOptimalBreaktTabLocations(g.TheGerber);
@@ -2107,7 +2107,7 @@ namespace GerberLibrary
 
 
                 Logger.AddString("writing " + a.GerberPath, ((float)current / (float)Instances.Count) * 0.3f);
-                if (a.GerberPath.Contains("???") == false)
+                if (a.GerberPath.Contains("???_negative") == false)
                 {
                     var outline = GerberOutlines[a.GerberPath];
                     List<String> FileList = new List<string>();

--- a/GerberLibrary/Core/GerberPanel.cs
+++ b/GerberLibrary/Core/GerberPanel.cs
@@ -1326,7 +1326,7 @@ namespace GerberLibrary
                         C = C.Rotate(-b.Angle);
                         var Box2 = a.TheGerber.BoundingBox.Grow(t.Radius * 2);
 
-                        if (Box2.Contains(C))
+                        if (Box2.Contains(C) || b.GerberPath.Contains("???_negative") == true)
                         {
                             //Console.WriteLine("{0},{1}", a.TheGerber.BoundingBox, C);
 


### PR DESCRIPTION
Rebase of #27 by CRImier

Works around the bug described in #17 .

It's a workaround which basically overrides the bounding box validity check for "???_negative" gerber, because for some reason the bounding box for "???_negative" gerber is calculated as (0, 0), (0, 0). I'm sorry, I couldn't find the place where gerber bounding box is calculated, so I made this workaround instead. From my (limited) understanding of the code and testing it with a couple of boards, this shouldn't introduce side-effects (but I'll be interested to hear your thoughts about any possible side effects there might be).

The PR also contains a commit replacing all .Contains("???") calls with Contains("???_negative"), so that there's less possibility of something crashing if somebody has ??? in his filenames.