### PR TITLE
Bugfix for bad "pacman" arc generation on breaktabs

### DIFF
--- a/GerberLibrary/Core/GerberPanel.cs
+++ b/GerberLibrary/Core/GerberPanel.cs
@@ -1102,8 +1102,10 @@ namespace GerberLibrary
 
                 var C1 = PStart + StartNorm * drillradius;
                 var C2 = PEnd + EndNorm * drillradius;
-
-                var DF = C2 - C1;
+                
+                //if centers are at the same location then the linesegment between them does not exist.  This results in a generating a bad unit vector and 
+                //therfore bad angles and bad arcs.  If the centers are at the same location use the linesgment between the start and end points instead.
+                var DF = (C1 != C2) ? C2 - C1 : PEnd - PStart;
                 DF.Normalize();
                 var DR = DF.Rotate(90);
 


### PR DESCRIPTION

![pacman](https://user-images.githubusercontent.com/71291173/93138803-d8273280-f69c-11ea-8a74-fb3c2fdf5dd6.PNG)

When generating the unit vector between the two arcs on breaktab generation if the arc centers share the same location then no line segment exists between them and a unit vector of (0.00,0.00) is generated.  This results in bad end angles and therefore bad arcs.  The fix for this is to use the line segment between start and end points instead in this special case.

This bug is mostly seen on horizontal breaktabs on rectangular boards spaced at 2mm (double the drillradius default of 1) but is suppressed in many cases due to floating point rounding errors giving slightly different centers.