### PR TITLE
build.sh interpreter changed to bash

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -euo pipefail
 set -x


### PR DESCRIPTION
This is a bash specific shell script. It seemingly works on many systems because sh is often a symlink to bash.