### PR TITLE
Add support Excellon cutter compensation (G40/G41/G42)

### DIFF
--- a/GerberLibrary/Core/Gerber.cs
+++ b/GerberLibrary/Core/Gerber.cs
@@ -685,6 +685,7 @@ namespace GerberLibrary
                 case "drill":
                 case "drillnpt":
                 case "rou":
+                case "sco":
                     Side = BoardSide.Both;
                     Layer = BoardLayer.Drill;
                     break;

--- a/GerberLibrary/Core/Gerber.cs
+++ b/GerberLibrary/Core/Gerber.cs
@@ -1,4 +1,4 @@
-﻿using ClipperLib;
+using ClipperLib;
 using GerberLibrary.Core.Primitives;
 using System;
 using System.Collections.Generic;
@@ -545,6 +545,7 @@ namespace GerberLibrary
 
                 case "l2":
                 case "gl1":
+                case "g1":
                     Side = BoardSide.Internal1;
                     Layer = BoardLayer.Copper;
                     break;
@@ -566,6 +567,7 @@ namespace GerberLibrary
 
                 case "l3":
                 case "gl2":
+                case "g2":
                     Side = BoardSide.Internal2;
                     Layer = BoardLayer.Copper;
                     break;
@@ -682,6 +684,7 @@ namespace GerberLibrary
                 case "drl":
                 case "drill":
                 case "drillnpt":
+                case "rou":
                     Side = BoardSide.Both;
                     Layer = BoardLayer.Drill;
                     break;

--- a/GerberLibrary/Core/GerberSplitter.cs
+++ b/GerberLibrary/Core/GerberSplitter.cs
@@ -24,6 +24,11 @@ namespace GerberLibrary
                 Number = form.Decode(running, hasdecimalpoint);
             }
         }
+
+        public override string ToString()
+        {
+            return $"{Command}{Number}";
+        }
     }
 
     public class GerberNumberPairList

--- a/GerberLibrary/Core/Primitives/PointD.cs
+++ b/GerberLibrary/Core/Primitives/PointD.cs
@@ -209,4 +209,12 @@ namespace GerberLibrary.Core.Primitives
         
     }
 
+    public static class Extensions
+    {
+        public static double Angle(this PointD p1, PointD p2)
+        {
+            return Math.Atan2(p2.Y - p1.Y, p2.X - p1.X);
+        }
+
+    }
 }


### PR DESCRIPTION
I had a panel created with Fab3000. The slots around the individual boards were created with cutter compensation.

**QuickGerberRender** was not rendering the slots correctly. After inspection the source code, I noticed the cutter compensation feature was not supported.

The logic I used to handle cutter compensation is relatively straight forward.

Once cutter compensation is engaged (G41 or G42), all the points are collected until cutter compensation is cancelled (G40). Then, all the points are processed by the _CutCompensation_ routine.

The _CutCompensation_ routine is responsible for:

a) removing any contiguous duplicated points. For example, _{ A, B, B, C, A, D, E, E, F }_ would become _{ A, B, C, A, D, E, F }_.
b) creating offset segments, by creating a line segment from two consecutive points and moving that line segment to the left or right from the direction of the path by the _offset_ amount.
c) figuring out how to join two consecutive offset segments.

There are 3 cases to handle:
1) if segments are colinear, the path is a line segment from the beginning of first segment to the end of the second segment;
2) if segments intersect, the path is line segment from the beginning of the first segment to the intersection point and then another line segment from the intersection point to the end of the second segment;
3) if segments do not intersect, cutter compensation dictates an arc is created to join the two consecutive offset segments.

Thank you,
Fabiano

PS: I also added file extensions that are used by Altium tools. Please let me know if you would like me to separate the pull request for them.