### PR TITLE
Add support for the Excellon Repeat drill code.

### DIFF
--- a/GerberLibrary/Core/ExcellonFile.cs
+++ b/GerberLibrary/Core/ExcellonFile.cs
@@ -546,9 +546,36 @@ namespace GerberLibrary
                                             LastX = x2;
                                             LastY = y2;
                                         }
+
                                         else
                                         {
-                                            if (GS.Has("X") || GS.Has("Y"))
+                                            //Deal with the repeat code
+                                            if (GS.Has("R") && (GS.Has("X") || GS.Has("Y")))
+                                            {
+                                                double repeatX = 0;
+                                                double repeatY = 0;
+
+                                                if (GS.Has("X"))
+                                                    repeatX = GNF.ScaleFileToMM(GS.Get("X") * Scaler);
+                                                if (GS.Has("Y"))
+                                                    repeatY = GNF.ScaleFileToMM(GS.Get("Y") * Scaler);
+
+                                                for (int repeatIndex = 1; repeatIndex <= GS.Get("R"); repeatIndex++)
+                                                {
+                                                    double X = LastX;
+                                                    if (GS.Has("X"))
+                                                        X += repeatX;
+
+                                                    double Y = LastY;
+                                                    if (GS.Has("Y"))
+                                                        Y += repeatY;
+
+                                                    CurrentTool.Drills.Add(new PointD(X * drillscaler, Y * drillscaler));
+                                                    LastX = X;
+                                                    LastY = Y;
+                                                }
+                                            }
+                                            else if (GS.Has("X") || GS.Has("Y"))
                                             {
                                                 double X = LastX;
                                                 if (GS.Has("X")) X = GNF.ScaleFileToMM(GS.Get("X") * Scaler);

--- a/GerberLibrary/Core/GerberSplitter.cs
+++ b/GerberLibrary/Core/GerberSplitter.cs
@@ -15,7 +15,7 @@ namespace GerberLibrary
 
         public void Parse(string running, GerberNumberFormat form, bool hasdecimalpoint = false)
         {
-            if (Command == "G" || Command == "D" || Command == "M")
+            if (Command == "G" || Command == "D" || Command == "M" || Command == "R")
             {
                 Number = (double)Int32.Parse(running);
             }


### PR DESCRIPTION
The Gerber Library does not support the Excellon "Repeat" code, used to repeat X number of times the last drill coordinate, with a X and/or Y offset for each repeat. This pull adds support for the repeat code.

In my case I wanted to use the Gerber Panelizer with a drill file generated by Orcad PCB Designer, which offer the option to use repeat codes in the drill file.

